### PR TITLE
Remove bird-liveness and readiness checks

### DIFF
--- a/cni/calico-mtu-vxlan.yml
+++ b/cni/calico-mtu-vxlan.yml
@@ -699,7 +699,6 @@ spec:
               command:
               - /bin/calico-node
               - -felix-live
-              - -bird-live
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
@@ -708,7 +707,6 @@ spec:
               command:
               - /bin/calico-node
               - -felix-ready
-              - -bird-ready
             periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules


### PR DESCRIPTION
BIRD is disabled by `calico_backend: "vxlan"` so we should remove the liveness and readiness checks for it, as per https://docs.projectcalico.org/getting-started/kubernetes/installation/config-options#switching-from-ip-in-ip-to-vxlan